### PR TITLE
Fixed gin-cli path

### DIFF
--- a/GinClientLibrary/GinRepository.cs
+++ b/GinClientLibrary/GinRepository.cs
@@ -33,6 +33,8 @@ namespace GinClientLibrary
             Removed
         }
 
+        private readonly string GinCliPath = AppDomain.CurrentDomain.BaseDirectory + "gin-cli\\";
+
         private static readonly StringBuilder Output = new StringBuilder("");
 
         private Dictionary<string, FileStatus> _scache;
@@ -60,7 +62,7 @@ namespace GinClientLibrary
         public bool DownloadUpdateInfo()
         {
             bool result = true;
-            GetCommandLineOutput("cmd.exe", "/C gin.exe download", PhysicalDirectory.FullName, out var error);
+            GetCommandLineOutput("cmd.exe", "/C "+ GinCliPath+"gin.exe download", PhysicalDirectory.FullName, out var error);
             if (!string.IsNullOrEmpty(error))
             {
                 OnFileOperationError(error);
@@ -128,7 +130,7 @@ namespace GinClientLibrary
         {
             lock (this)
             {
-                var output = GetCommandLineOutput("cmd.exe", "/c gin.exe ls --json", PhysicalDirectory.FullName,
+                var output = GetCommandLineOutput("cmd.exe", "/c "+ GinCliPath+"gin.exe ls --json", PhysicalDirectory.FullName,
                     out var error);
                 if (!string.IsNullOrEmpty(error))
                 {
@@ -188,7 +190,7 @@ namespace GinClientLibrary
             GetActualFilename(filePath, out var directoryName, out var filename);
             lock (this)
             {
-                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe get-content --json \"" + filename + "\"",
+                GetCommandLineOutputEvent("cmd.exe", "/C "+ GinCliPath+"gin.exe get-content --json \"" + filename + "\"",
                     directoryName,
                     out var error);
                 ReadRepoStatus();
@@ -220,7 +222,7 @@ namespace GinClientLibrary
             lock (this)
             {
                 OnFileOperationStarted(new FileOperationEventArgs { File = filename });
-                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe upload --json " + filename, directoryName,
+                GetCommandLineOutputEvent("cmd.exe", "/C "+ GinCliPath+"gin.exe upload --json " + filename, directoryName,
                     out var error);
                 ReadRepoStatus();
                 var result = string.IsNullOrEmpty(error);
@@ -252,9 +254,9 @@ namespace GinClientLibrary
             lock (this)
             {
                 OnFileOperationStarted(new FileOperationEventArgs { File = filename });
-                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe commit --json -m \"" + CheckMessage(message) + "\" " + filename, directoryName,
+                GetCommandLineOutputEvent("cmd.exe", "/C "+ GinCliPath+"gin.exe commit --json -m \"" + CheckMessage(message) + "\" " + filename, directoryName,
                     out var cError);
-                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe upload --json " + filename, directoryName,
+                GetCommandLineOutputEvent("cmd.exe", "/C "+ GinCliPath+"gin.exe upload --json " + filename, directoryName,
                     out var error);
                 ReadRepoStatus();
                 var result = string.IsNullOrEmpty(error);
@@ -271,7 +273,7 @@ namespace GinClientLibrary
         {
             lock (this)
             {
-                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe upload --json", PhysicalDirectory.FullName,
+                GetCommandLineOutputEvent("cmd.exe", "/C "+ GinCliPath+"gin.exe upload --json", PhysicalDirectory.FullName,
                     out var error);
                 ReadRepoStatus();
                 if (!string.IsNullOrEmpty(error))
@@ -288,14 +290,14 @@ namespace GinClientLibrary
             lock (this)
             {
                 message = CheckMessage(message);
-                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe commit --json -m " + "\"" + message + "\"", PhysicalDirectory.FullName,
+                GetCommandLineOutputEvent("cmd.exe", "/C "+ GinCliPath+"gin.exe commit --json -m " + "\"" + message + "\"", PhysicalDirectory.FullName,
                     out var cError);
                 if (!string.IsNullOrEmpty(cError))
                 {
                     OnFileOperationError(cError);
                     return;
                 }
-                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe upload --json", PhysicalDirectory.FullName,
+                GetCommandLineOutputEvent("cmd.exe", "/C "+ GinCliPath+"gin.exe upload --json", PhysicalDirectory.FullName,
                     out var error);
                 ReadRepoStatus();
                 if (!string.IsNullOrEmpty(error))
@@ -327,7 +329,7 @@ namespace GinClientLibrary
 
             lock (this)
             {
-                GetCommandLineOutput("cmd.exe", "/C gin.exe remove-content \"" + filename + "\"" /*+ " -json"*/,
+                GetCommandLineOutput("cmd.exe", "/C "+GinCliPath+"gin.exe remove-content \"" + filename + "\"" /*+ " -json"*/,
                     directoryName, out var error);
                 Output.Clear();
                 ReadRepoStatus();
@@ -348,7 +350,7 @@ namespace GinClientLibrary
         {
             lock (this)
             {
-                var message = GetCommandLineOutput("cmd.exe", "/C gin.exe version --id " + versInfo.hash + " --copy-to \"" + dirName + "\" " + filename,
+                var message = GetCommandLineOutput("cmd.exe", "/C "+ GinCliPath+"gin.exe version --id " + versInfo.hash + " --copy-to \"" + dirName + "\" " + filename,
                     dirName, out var error);
                 MessageBox.Show(message, "Version checkout result", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 Output.Clear();
@@ -370,7 +372,7 @@ namespace GinClientLibrary
             lock (this)
             {
                 ///get all available versions for the specified file in json
-                var versionJson = GetCommandLineOutput("cmd.exe", "/C gin.exe version --json " + filename,
+                var versionJson = GetCommandLineOutput("cmd.exe", "/C "+ GinCliPath+"gin.exe version --json " + filename,
                      directoryName, out var error);
 
                 Output.Clear();
@@ -446,7 +448,7 @@ namespace GinClientLibrary
             if (PhysicalDirectory.IsEmpty())
             {
                 OnFileOperationStarted(new FileOperationEventArgs { File = Address });
-                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe get --json " + Address,
+                GetCommandLineOutputEvent("cmd.exe", "/C "+ GinCliPath+"gin.exe get --json " + Address,
                     PhysicalDirectory.Parent.FullName, out var error);
                 var result = string.IsNullOrEmpty(error);
                 if (result)
@@ -461,7 +463,7 @@ namespace GinClientLibrary
             if (performFullCheckout)
             {
                 OnFileOperationStarted(new FileOperationEventArgs { File = Address });
-                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe download --json --content",
+                GetCommandLineOutputEvent("cmd.exe", "/C "+ GinCliPath+"gin.exe download --json --content",
                     PhysicalDirectory.FullName, out var error);
                 var result = string.IsNullOrEmpty(error);
                 if (result)

--- a/GinClientLibrary/RepositoryManager.cs
+++ b/GinClientLibrary/RepositoryManager.cs
@@ -36,6 +36,8 @@ namespace GinClientLibrary
 
         private readonly object _thisLock = new object();
 
+        private readonly string GinCliPath = AppDomain.CurrentDomain.BaseDirectory+"gin-cli\\";
+
         private List<GinRepository> _repositories;
 
         private const string ginError= "Gin Error! Error message is: ";
@@ -72,7 +74,7 @@ namespace GinClientLibrary
                     {
                         WindowStyle = ProcessWindowStyle.Hidden,
                         FileName = "gin.exe",
-                        WorkingDirectory = @"C:\",
+                        WorkingDirectory = GinCliPath,
                         Arguments = "use-server \""+alias+"\"",
                         CreateNoWindow = true,
                         RedirectStandardOutput = true,
@@ -106,7 +108,7 @@ namespace GinClientLibrary
                     {
                         WindowStyle = ProcessWindowStyle.Hidden,
                         FileName = "cmd.exe",
-                        WorkingDirectory = @"C:\",
+                        WorkingDirectory = GinCliPath,
                         Arguments = "/C gin.exe logout",
                         CreateNoWindow = true,
                         RedirectStandardOutput = true,
@@ -130,7 +132,7 @@ namespace GinClientLibrary
                     {
                         WindowStyle = ProcessWindowStyle.Hidden,
                         FileName = "cmd.exe",
-                        WorkingDirectory = @"C:\",
+                        WorkingDirectory = GinCliPath,
                         Arguments = "/C gin.exe create --no-clone " + repoName,
                         CreateNoWindow = true,
                         RedirectStandardOutput = true,
@@ -160,7 +162,7 @@ namespace GinClientLibrary
                     {
                         WindowStyle = ProcessWindowStyle.Hidden,
                         FileName = "gin.exe",
-                        WorkingDirectory = @"C:\",
+                        WorkingDirectory = GinCliPath,
                         Arguments = "servers --json ",
                         CreateNoWindow = true,
                         RedirectStandardOutput = true,
@@ -200,7 +202,7 @@ namespace GinClientLibrary
                     {
                         WindowStyle = ProcessWindowStyle.Hidden,
                         FileName = "gin.exe",
-                        WorkingDirectory = @"C:\",
+                        WorkingDirectory = GinCliPath,
                         Arguments = "add-server --web "+ web + " --git "+git+" "+ "\""+alias+"\"" ,
                         CreateNoWindow = true,
                         RedirectStandardOutput = true,
@@ -239,7 +241,7 @@ namespace GinClientLibrary
                     {
                         WindowStyle = ProcessWindowStyle.Hidden,
                         FileName = "gin.exe",
-                        WorkingDirectory = @"C:\",
+                        WorkingDirectory = GinCliPath,
                         Arguments = "remove-server "  + "\""+alias+"\"",
                         CreateNoWindow = true,
                         RedirectStandardOutput = true,
@@ -272,7 +274,7 @@ namespace GinClientLibrary
                     {
                         WindowStyle = ProcessWindowStyle.Hidden,
                         FileName = "cmd.exe",
-                        WorkingDirectory = @"C:\",
+                        WorkingDirectory = GinCliPath,
                         Arguments = @"/C gin.exe login " + username +" --server "+ "\""+serverAlias+"\"",
                         CreateNoWindow = true,
                         RedirectStandardOutput = true,
@@ -334,7 +336,7 @@ namespace GinClientLibrary
                 {
                     WindowStyle = ProcessWindowStyle.Hidden,
                     FileName = "cmd.exe",
-                    WorkingDirectory = @"C:\",
+                    WorkingDirectory = GinCliPath,
                     Arguments = @"/C gin.exe --version",
                     CreateNoWindow = true,
                     RedirectStandardOutput = true,
@@ -343,7 +345,6 @@ namespace GinClientLibrary
                     UseShellExecute = false
                 }
             };
-
             process.OutputDataReceived += Process_OutputDataReceived;
             lock (_thisLock)
             {
@@ -555,7 +556,7 @@ namespace GinClientLibrary
                 {
                     WindowStyle = ProcessWindowStyle.Hidden,
                     FileName = "gin.exe",
-                    WorkingDirectory = @"C:\",
+                    WorkingDirectory = GinCliPath,
                     Arguments = "repos --json --all",
                     CreateNoWindow = true,
                     RedirectStandardOutput = true,
@@ -583,7 +584,7 @@ namespace GinClientLibrary
                 {
                     WindowStyle = ProcessWindowStyle.Hidden,
                     FileName = "gin.exe",
-                    WorkingDirectory = @"C:\",
+                    WorkingDirectory = GinCliPath,
                     Arguments = "repoinfo --json " + path,
                     CreateNoWindow = true,
                     RedirectStandardOutput = true,

--- a/GinClientLibrary/RepositoryManager.cs
+++ b/GinClientLibrary/RepositoryManager.cs
@@ -189,7 +189,7 @@ namespace GinClientLibrary
         /// <param name="alias">new server alias</param>
         /// <param name="web">new web configuration string http[s]://hostname:port</param>
         /// <param name="git">new git configuration gituser@hostname:port</param>
-        /// <returns>true for succes</returns>
+        /// <returns>true for success</returns>
         public bool AddServer(string alias, string web, string git)
         {
             lock (this)
@@ -228,7 +228,7 @@ namespace GinClientLibrary
         /// remove server configuration to gin-cli
         /// </summary>
         /// <param name="alias">delete server alias</param>
-        /// <returns>true for succes</returns>
+        /// <returns>true for success</returns>
         public bool DeleteServer(string alias)
         {
             lock (this)

--- a/Updater/UpdateChecker.cs
+++ b/Updater/UpdateChecker.cs
@@ -16,7 +16,7 @@ namespace Updater
         /// </summary>
         private static readonly DirectoryInfo UpdaterBaseDirectory = new DirectoryInfo(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + @"\g-node\WinGIN\Updates\");
         /// <summary>
-        /// url for nevest released version of WinGIN msi
+        /// url for latest released version of WinGIN msi
         /// </summary>
         private const string UpdatedMsi = "https://web.gin.g-node.org/G-Node/wingin-installers/raw/master/Setup.msi";
         /// <summary>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.{build}
+version: 1.1.{build}
 
 image: Visual Studio 2017
 shallow_clone: true


### PR DESCRIPTION
all working directories and gin-cli commands now uses local gin in WinGIN directory;
Fixed Typos
Fixes https://github.com/G-Node/WinGIN/issues/143 
gin-cli still added in %PATH% during installation 