### PR TITLE
Gin-cli Path Fix

### DIFF
--- a/GinClientApp/Dialogs/MetroGetUserCredentialsDlg.cs
+++ b/GinClientApp/Dialogs/MetroGetUserCredentialsDlg.cs
@@ -46,15 +46,16 @@ namespace GinClientApp.Dialogs
             
             
         }
-
+        /// <summary>
+        /// try to login; check name, password, server, logout and then login
+        /// </summary>
+        /// <returns>true for successful login</returns>
         private bool AttemptLogin()
         {
-            if (string.IsNullOrEmpty(mTxBUsername.Text) || string.IsNullOrEmpty(mTxBPassword.Text) || string.IsNullOrEmpty((string)mCBxServerAlias.SelectedValue)) return false;
-
+            if (string.IsNullOrEmpty(mTxBUsername.Text) || string.IsNullOrEmpty(mTxBPassword.Text) || string.IsNullOrEmpty((string)mCBxServerAlias.SelectedValue))
+                return false;
             _parentContext.ServiceClient.Logout();
-
             return _parentContext.ServiceClient.Login(mTxBUsername.Text, mTxBPassword.Text, (string)mCBxServerAlias.SelectedValue);
-            //return _parentContext.ServiceClient.Login(mTxBUsername.Text, mTxBPassword.Text);
         }
 
         private void mBtnOk_Click(object sender, EventArgs e)

--- a/GinClientApp/Dialogs/MetroOptionsDlg.cs
+++ b/GinClientApp/Dialogs/MetroOptionsDlg.cs
@@ -307,7 +307,7 @@ namespace GinClientApp.Dialogs
                 .GetRepositoryList());
 
             var saveFile = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) +
-                           @"\g-node\GinWindowsClient\SavedRepositories.json";
+                           @"\g-node\WinGIN\SavedRepositories.json";
 
             if (!Directory.Exists(Path.GetDirectoryName(saveFile)))
                 Directory.CreateDirectory(Path.GetDirectoryName(saveFile));

--- a/GinClientApp/Dialogs/MetroOptionsDlg.cs
+++ b/GinClientApp/Dialogs/MetroOptionsDlg.cs
@@ -358,6 +358,7 @@ namespace GinClientApp.Dialogs
             _parentContext.ServiceClient.DeleteRepository(repo);
 
             FillRepoList();
+            SaveRepoList();
         }
 
         private void StartShowProgress()

--- a/GinClientApp/Dialogs/MetroOptionsDlg.cs
+++ b/GinClientApp/Dialogs/MetroOptionsDlg.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -212,7 +211,7 @@ namespace GinClientApp.Dialogs
             GlobalOptions.Instance.DefaultCheckoutDir = directory;
         }
         /// <summary>
-        /// opens EditSvrDlg and represhes server combobox
+        /// opens EditSvrDlg and refreshes server combobox
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>

--- a/GinClientApp/Dialogs/MetroOptionsDlg.cs
+++ b/GinClientApp/Dialogs/MetroOptionsDlg.cs
@@ -434,7 +434,7 @@ namespace GinClientApp.Dialogs
             }
         }
         /// <summary>
-        /// Default button click - sets as default server selected server in mCBxServer and represhes combobox
+        /// Default button click - sets as default server selected server in mCBxServer and refreshes combobox
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
@@ -489,10 +489,12 @@ namespace GinClientApp.Dialogs
         private void OpenHelp() {
             bool exists = false;
             FormCollection openforms = Application.OpenForms;
+            ///check if help is already open
             foreach (Form forms in openforms)
             {
                 if (forms.Name == "HelpForm")
                 {
+                    ///if help is open bring it to the top
                     exists = true;
                     forms.Activate();
                     break;
@@ -500,6 +502,7 @@ namespace GinClientApp.Dialogs
             }
             if (!exists)
             {
+                ///help is closed, open it
                 Form helpF = new HelpForm();
                 helpF.Show();
             }

--- a/GinClientApp/GinApplicationContext.cs
+++ b/GinClientApp/GinApplicationContext.cs
@@ -68,7 +68,7 @@ namespace GinClientApp
 
             ServiceClient = myChannelFactory.CreateChannel();
             var saveFilePath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) +
-                                @"\g-node\GinWindowsClient";
+                                @"\g-node\WinGIN";
             if (!Directory.Exists(saveFilePath))
                 Directory.CreateDirectory(saveFilePath);
 

--- a/GinClientApp/GinApplicationContext.cs
+++ b/GinClientApp/GinApplicationContext.cs
@@ -109,12 +109,12 @@ namespace GinClientApp
                         {
                             if (server.Value.Default)
                             {
-                                //if login fails for default server, try to get new login info
+                                ///if login fails for default server, try to get new login info
                                 MessageBox.Show(Resources.GinApplicationContext_Error_while_trying_to_log_in_to_GIN,
                                 Resources.GinApplicationContext_Gin_Client_Error,
                                 MessageBoxButtons.OK, MessageBoxIcon.Error);
                                 var getUserCreds = new MetroGetUserCredentialsDlg(this);
-                                var result = getUserCreds.ShowDialog(); //The Dialog will log us in and save the user credentials
+                                var result = getUserCreds.ShowDialog(); ///The Dialog will log us in and save the user credentials
                                 if (result == DialogResult.Cancel)
                                 {
                                     Exit(this, EventArgs.Empty);

--- a/GinClientApp/GlobalOptions.cs
+++ b/GinClientApp/GlobalOptions.cs
@@ -23,7 +23,7 @@ namespace GinClientApp
             RepositoryCheckoutOption = CheckoutOption.AnnexCheckout;
             DefaultCheckoutDir =
                 new DirectoryInfo(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) +
-                                  @"\g-node\GinWindowsClient\Repositories");
+                                  @"\g-node\WinGIN\Repositories");
             DefaultMountpointDir =
                 new DirectoryInfo(Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory) +
                                   @"\Gin Repositories");
@@ -69,7 +69,7 @@ namespace GinClientApp
         public static void Save()
         {
             var saveFilePath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) +
-                               @"\g-node\GinWindowsClient\GlobalOptionsDlg.json";
+                               @"\g-node\WinGIN\GlobalOptionsDlg.json";
 
             if (File.Exists(saveFilePath))
                 File.Delete(saveFilePath);
@@ -86,7 +86,7 @@ namespace GinClientApp
         public static bool Load()
         {
             var saveFilePath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) +
-                               @"\g-node\GinWindowsClient\GlobalOptionsDlg.json";
+                               @"\g-node\WinGIN\GlobalOptionsDlg.json";
             if (!Directory.Exists(Path.GetDirectoryName(saveFilePath)))
                 Directory.CreateDirectory(Path.GetDirectoryName(saveFilePath));
 

--- a/GinClientApp/Installer.cs
+++ b/GinClientApp/Installer.cs
@@ -35,7 +35,7 @@ namespace GinClientApp
             deleteDlg.ShowDialog();
 
             var configDataPath = new DirectoryInfo(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) +
-                                 @"\g-node\GinWindowsClient\");
+                                 @"\g-node\WinGIN\");
 
             if (!deleteDlg.KeepCheckout)
             {

--- a/GinClientApp/Program.cs
+++ b/GinClientApp/Program.cs
@@ -30,7 +30,7 @@ namespace GinClientApp
         #region Forms Strings
         private const string dokanApp = "Dokan Library 1.1.0.2000 Bundle";
         private const string connectionError = "Cannot connect to G-Node server.";
-        private const string dokanNotInstalled = "Dokan library is missing! Please install Dokan. Do you want to install Dokan now?";
+        private const string dokanNotInstalled = "Dokan library is missing! Dokan is necessary for WinGIN to work. Do you want to install Dokan now?";
         private const string ginNotInstalled = "Local GIN binary is missing. Please reinstall application.";
         private const string winginIsRunning = "WinGIN is already running.";
         #endregion

--- a/GinClientApp/Program.cs
+++ b/GinClientApp/Program.cs
@@ -21,7 +21,7 @@ namespace GinClientApp
         /// <summary>
         /// Directory for updater; latest msi is downloaded there
         /// </summary>
-        private static readonly DirectoryInfo UpdaterBaseDirectory = new DirectoryInfo(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + @"\g-node\GinWindowsClient\Updates\");
+        private static readonly DirectoryInfo UpdaterBaseDirectory = new DirectoryInfo(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + @"\g-node\WinGIN\Updates\");
         /// <summary>
         /// Link to AppVeyor project json; used to check latest released version: version.subversion.build
         /// </summary>

--- a/GinClientApp/Program.cs
+++ b/GinClientApp/Program.cs
@@ -31,7 +31,7 @@ namespace GinClientApp
         private const string dokanApp = "Dokan Library 1.1.0.2000 Bundle";
         private const string connectionError = "Cannot connect to G-Node server.";
         private const string dokanNotInstalled = "Dokan library is missing! Please install Dokan. Do you want to install Dokan now?";
-        private const string ginNotInstalled = "GIN binary is missing. Please reinstall application.";
+        private const string ginNotInstalled = "Local GIN binary is missing. Please reinstall application.";
         private const string winginIsRunning = "WinGIN is already running.";
         #endregion
 
@@ -120,7 +120,7 @@ namespace GinClientApp
                     return;
                 }
             }
-            ///check if gin-cli is present
+            ///check if local gin-cli is present
             if (!File.Exists(curPath + @"gin-cli/bin/gin.exe"))
             {
                 var result = MessageBox.Show(ginNotInstalled, "WinGIN", MessageBoxButton.OK, MessageBoxImage.Warning);

--- a/GinClientApp/UserCredentials.cs
+++ b/GinClientApp/UserCredentials.cs
@@ -39,7 +39,7 @@ namespace GinClientApp
         public static bool Load()
         {
             var saveFilePath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) +
-                               @"\g-node\GinWindowsClient\UserCredentials.json";
+                               @"\g-node\WinGIN\UserCredentials.json";
 
             if (!Directory.Exists(Path.GetDirectoryName(saveFilePath)))
                 Directory.CreateDirectory(Path.GetDirectoryName(saveFilePath));
@@ -68,7 +68,7 @@ namespace GinClientApp
         public static void Save()
         {
             var saveFilePath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) +
-                               @"\g-node\GinWindowsClient\UserCredentials.json";
+                               @"\g-node\WinGIN\UserCredentials.json";
 
             if (File.Exists(saveFilePath))
                 File.Delete(saveFilePath);

--- a/GinClientLibrary/GinRepository.cs
+++ b/GinClientLibrary/GinRepository.cs
@@ -33,7 +33,7 @@ namespace GinClientLibrary
             Removed
         }
 
-        private readonly string GinCliPath = AppDomain.CurrentDomain.BaseDirectory + "gin-cli\\";
+        private readonly string GinCliPath = AppDomain.CurrentDomain.BaseDirectory + "gin-cli\\\bin\\";
 
         private static readonly StringBuilder Output = new StringBuilder("");
 

--- a/GinClientLibrary/GinRepository.cs
+++ b/GinClientLibrary/GinRepository.cs
@@ -33,7 +33,6 @@ namespace GinClientLibrary
             Removed
         }
 
-        private readonly string GinCliPath = AppDomain.CurrentDomain.BaseDirectory + "gin-cli\\bin\\";
         private readonly string GinCliExe = "\""+AppDomain.CurrentDomain.BaseDirectory + "gin-cli\\bin\\gin.exe\"";
 
         private static readonly StringBuilder Output = new StringBuilder("");
@@ -63,7 +62,7 @@ namespace GinClientLibrary
         public bool DownloadUpdateInfo()
         {
             bool result = true;
-            GetCommandLineOutput("cmd.exe", "/C gin.exe download", PhysicalDirectory.FullName, out var error);
+            GetCommandLineOutput(GinCliExe, " download", PhysicalDirectory.FullName, out var error);
             if (!string.IsNullOrEmpty(error))
             {
                 OnFileOperationError(error);

--- a/GinClientLibrary/GinRepository.cs
+++ b/GinClientLibrary/GinRepository.cs
@@ -667,9 +667,9 @@ namespace GinClientLibrary
                     StartInfo = new ProcessStartInfo
                     {
                         WindowStyle = ProcessWindowStyle.Hidden,
-                        FileName = program,
-                        WorkingDirectory = workingDirectory,
-                        Arguments = commandline,
+                        FileName = @program,
+                        WorkingDirectory = @workingDirectory,
+                        Arguments = @commandline,
                         CreateNoWindow = true,
                         RedirectStandardOutput = true,
                         RedirectStandardError = true,

--- a/GinClientLibrary/GinRepository.cs
+++ b/GinClientLibrary/GinRepository.cs
@@ -62,7 +62,7 @@ namespace GinClientLibrary
         public bool DownloadUpdateInfo()
         {
             bool result = true;
-            GetCommandLineOutput("cmd.exe", "/C "+ GinCliPath+"gin.exe download", PhysicalDirectory.FullName, out var error);
+            GetCommandLineOutput("cmd.exe", "/C gin.exe download", PhysicalDirectory.FullName, out var error);
             if (!string.IsNullOrEmpty(error))
             {
                 OnFileOperationError(error);
@@ -130,7 +130,7 @@ namespace GinClientLibrary
         {
             lock (this)
             {
-                var output = GetCommandLineOutput("cmd.exe", "/c "+ GinCliPath+"gin.exe ls --json", PhysicalDirectory.FullName,
+                var output = GetCommandLineOutput("cmd.exe", "/c gin.exe ls --json", PhysicalDirectory.FullName,
                     out var error);
                 if (!string.IsNullOrEmpty(error))
                 {
@@ -190,7 +190,7 @@ namespace GinClientLibrary
             GetActualFilename(filePath, out var directoryName, out var filename);
             lock (this)
             {
-                GetCommandLineOutputEvent("cmd.exe", "/C "+ GinCliPath+"gin.exe get-content --json \"" + filename + "\"",
+                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe get-content --json \"" + filename + "\"",
                     directoryName,
                     out var error);
                 ReadRepoStatus();
@@ -222,7 +222,7 @@ namespace GinClientLibrary
             lock (this)
             {
                 OnFileOperationStarted(new FileOperationEventArgs { File = filename });
-                GetCommandLineOutputEvent("cmd.exe", "/C "+ GinCliPath+"gin.exe upload --json " + filename, directoryName,
+                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe upload --json " + filename, directoryName,
                     out var error);
                 ReadRepoStatus();
                 var result = string.IsNullOrEmpty(error);
@@ -254,9 +254,9 @@ namespace GinClientLibrary
             lock (this)
             {
                 OnFileOperationStarted(new FileOperationEventArgs { File = filename });
-                GetCommandLineOutputEvent("cmd.exe", "/C "+ GinCliPath+"gin.exe commit --json -m \"" + CheckMessage(message) + "\" " + filename, directoryName,
+                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe commit --json -m \"" + CheckMessage(message) + "\" " + filename, directoryName,
                     out var cError);
-                GetCommandLineOutputEvent("cmd.exe", "/C "+ GinCliPath+"gin.exe upload --json " + filename, directoryName,
+                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe upload --json " + filename, directoryName,
                     out var error);
                 ReadRepoStatus();
                 var result = string.IsNullOrEmpty(error);
@@ -273,7 +273,7 @@ namespace GinClientLibrary
         {
             lock (this)
             {
-                GetCommandLineOutputEvent("cmd.exe", "/C "+ GinCliPath+"gin.exe upload --json", PhysicalDirectory.FullName,
+                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe upload --json", PhysicalDirectory.FullName,
                     out var error);
                 ReadRepoStatus();
                 if (!string.IsNullOrEmpty(error))
@@ -290,14 +290,14 @@ namespace GinClientLibrary
             lock (this)
             {
                 message = CheckMessage(message);
-                GetCommandLineOutputEvent("cmd.exe", "/C "+ GinCliPath+"gin.exe commit --json -m " + "\"" + message + "\"", PhysicalDirectory.FullName,
+                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe commit --json -m " + "\"" + message + "\"", PhysicalDirectory.FullName,
                     out var cError);
                 if (!string.IsNullOrEmpty(cError))
                 {
                     OnFileOperationError(cError);
                     return;
                 }
-                GetCommandLineOutputEvent("cmd.exe", "/C "+ GinCliPath+"gin.exe upload --json", PhysicalDirectory.FullName,
+                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe upload --json", PhysicalDirectory.FullName,
                     out var error);
                 ReadRepoStatus();
                 if (!string.IsNullOrEmpty(error))
@@ -329,7 +329,7 @@ namespace GinClientLibrary
 
             lock (this)
             {
-                GetCommandLineOutput("cmd.exe", "/C "+GinCliPath+"gin.exe remove-content \"" + filename + "\"" /*+ " -json"*/,
+                GetCommandLineOutput("cmd.exe", "/C gin.exe remove-content \"" + filename + "\"" /*+ " -json"*/,
                     directoryName, out var error);
                 Output.Clear();
                 ReadRepoStatus();
@@ -350,7 +350,7 @@ namespace GinClientLibrary
         {
             lock (this)
             {
-                var message = GetCommandLineOutput("cmd.exe", "/C "+ GinCliPath+"gin.exe version --id " + versInfo.hash + " --copy-to \"" + dirName + "\" " + filename,
+                var message = GetCommandLineOutput("cmd.exe", "/C gin.exe version --id " + versInfo.hash + " --copy-to \"" + dirName + "\" " + filename,
                     dirName, out var error);
                 MessageBox.Show(message, "Version checkout result", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 Output.Clear();
@@ -372,7 +372,7 @@ namespace GinClientLibrary
             lock (this)
             {
                 ///get all available versions for the specified file in json
-                var versionJson = GetCommandLineOutput("cmd.exe", "/C "+ GinCliPath+"gin.exe version --json " + filename,
+                var versionJson = GetCommandLineOutput("cmd.exe", "/C gin.exe version --json " + filename,
                      directoryName, out var error);
 
                 Output.Clear();
@@ -448,7 +448,7 @@ namespace GinClientLibrary
             if (PhysicalDirectory.IsEmpty())
             {
                 OnFileOperationStarted(new FileOperationEventArgs { File = Address });
-                GetCommandLineOutputEvent("cmd.exe", "/C "+ GinCliPath+"gin.exe get --json " + Address,
+                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe get --json " + Address,
                     PhysicalDirectory.Parent.FullName, out var error);
                 var result = string.IsNullOrEmpty(error);
                 if (result)
@@ -463,7 +463,7 @@ namespace GinClientLibrary
             if (performFullCheckout)
             {
                 OnFileOperationStarted(new FileOperationEventArgs { File = Address });
-                GetCommandLineOutputEvent("cmd.exe", "/C "+ GinCliPath+"gin.exe download --json --content",
+                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe download --json --content",
                     PhysicalDirectory.FullName, out var error);
                 var result = string.IsNullOrEmpty(error);
                 if (result)
@@ -628,9 +628,9 @@ namespace GinClientLibrary
                     StartInfo = new ProcessStartInfo
                     {
                         WindowStyle = ProcessWindowStyle.Hidden,
-                        FileName = program,
-                        WorkingDirectory = workingDirectory,
-                        Arguments = commandline,
+                        FileName = @program,
+                        WorkingDirectory = @workingDirectory,
+                        Arguments = @commandline,
                         CreateNoWindow = true,
                         RedirectStandardOutput = true,
                         RedirectStandardError = true,

--- a/GinClientLibrary/GinRepository.cs
+++ b/GinClientLibrary/GinRepository.cs
@@ -33,7 +33,8 @@ namespace GinClientLibrary
             Removed
         }
 
-        private readonly string GinCliPath = AppDomain.CurrentDomain.BaseDirectory + "gin-cli\\\bin\\";
+        private readonly string GinCliPath = AppDomain.CurrentDomain.BaseDirectory + "gin-cli\\bin\\";
+        private readonly string GinCliExe = "\""+AppDomain.CurrentDomain.BaseDirectory + "gin-cli\\bin\\gin.exe\"";
 
         private static readonly StringBuilder Output = new StringBuilder("");
 
@@ -130,7 +131,7 @@ namespace GinClientLibrary
         {
             lock (this)
             {
-                var output = GetCommandLineOutput("cmd.exe", "/c gin.exe ls --json", PhysicalDirectory.FullName,
+                var output = GetCommandLineOutput(GinCliExe, " ls --json", PhysicalDirectory.FullName,
                     out var error);
                 if (!string.IsNullOrEmpty(error))
                 {
@@ -171,7 +172,7 @@ namespace GinClientLibrary
             if (StatusCache.ContainsKey(filePath.ToLowerInvariant()))
                 return StatusCache[filePath.ToLowerInvariant()];
 
-            ///Windows will sometimes try to inspect the contents of a zip file; we need to catch this here and return the filestatus of the zip
+            ///Windows will sometimes try to inspect the contents of a zip file; we need to catch this here and return the file status of the zip
             var parentDirectory = Directory.GetParent(filePath).FullName;
             if (parentDirectory.ToLower().Contains(".zip"))
                 return GetFileStatus(parentDirectory);
@@ -190,7 +191,7 @@ namespace GinClientLibrary
             GetActualFilename(filePath, out var directoryName, out var filename);
             lock (this)
             {
-                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe get-content --json \"" + filename + "\"",
+                GetCommandLineOutputEvent(GinCliExe, " get-content --json \"" + filename + "\"",
                     directoryName,
                     out var error);
                 ReadRepoStatus();
@@ -222,7 +223,7 @@ namespace GinClientLibrary
             lock (this)
             {
                 OnFileOperationStarted(new FileOperationEventArgs { File = filename });
-                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe upload --json " + filename, directoryName,
+                GetCommandLineOutputEvent(GinCliExe, " upload --json " + filename, directoryName,
                     out var error);
                 ReadRepoStatus();
                 var result = string.IsNullOrEmpty(error);
@@ -254,9 +255,9 @@ namespace GinClientLibrary
             lock (this)
             {
                 OnFileOperationStarted(new FileOperationEventArgs { File = filename });
-                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe commit --json -m \"" + CheckMessage(message) + "\" " + filename, directoryName,
+                GetCommandLineOutputEvent(GinCliExe, " commit --json -m \"" + CheckMessage(message) + "\" " + filename, directoryName,
                     out var cError);
-                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe upload --json " + filename, directoryName,
+                GetCommandLineOutputEvent(GinCliExe, " upload --json " + filename, directoryName,
                     out var error);
                 ReadRepoStatus();
                 var result = string.IsNullOrEmpty(error);
@@ -273,7 +274,7 @@ namespace GinClientLibrary
         {
             lock (this)
             {
-                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe upload --json", PhysicalDirectory.FullName,
+                GetCommandLineOutputEvent(GinCliExe, " upload --json", PhysicalDirectory.FullName,
                     out var error);
                 ReadRepoStatus();
                 if (!string.IsNullOrEmpty(error))
@@ -290,14 +291,14 @@ namespace GinClientLibrary
             lock (this)
             {
                 message = CheckMessage(message);
-                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe commit --json -m " + "\"" + message + "\"", PhysicalDirectory.FullName,
+                GetCommandLineOutputEvent(GinCliExe, " commit --json -m " + "\"" + message + "\"", PhysicalDirectory.FullName,
                     out var cError);
                 if (!string.IsNullOrEmpty(cError))
                 {
                     OnFileOperationError(cError);
                     return;
                 }
-                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe upload --json", PhysicalDirectory.FullName,
+                GetCommandLineOutputEvent(GinCliExe, " upload --json", PhysicalDirectory.FullName,
                     out var error);
                 ReadRepoStatus();
                 if (!string.IsNullOrEmpty(error))
@@ -329,7 +330,7 @@ namespace GinClientLibrary
 
             lock (this)
             {
-                GetCommandLineOutput("cmd.exe", "/C gin.exe remove-content \"" + filename + "\"" /*+ " -json"*/,
+                GetCommandLineOutput(GinCliExe, " remove-content \"" + filename + "\"" /*+ " -json"*/,
                     directoryName, out var error);
                 Output.Clear();
                 ReadRepoStatus();
@@ -350,7 +351,7 @@ namespace GinClientLibrary
         {
             lock (this)
             {
-                var message = GetCommandLineOutput("cmd.exe", "/C gin.exe version --id " + versInfo.hash + " --copy-to \"" + dirName + "\" " + filename,
+                var message = GetCommandLineOutput(GinCliExe, " version --id " + versInfo.hash + " --copy-to \"" + dirName + "\" " + filename,
                     dirName, out var error);
                 MessageBox.Show(message, "Version checkout result", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 Output.Clear();
@@ -372,7 +373,7 @@ namespace GinClientLibrary
             lock (this)
             {
                 ///get all available versions for the specified file in json
-                var versionJson = GetCommandLineOutput("cmd.exe", "/C gin.exe version --json " + filename,
+                var versionJson = GetCommandLineOutput(GinCliExe, " version --json " + filename,
                      directoryName, out var error);
 
                 Output.Clear();
@@ -448,7 +449,7 @@ namespace GinClientLibrary
             if (PhysicalDirectory.IsEmpty())
             {
                 OnFileOperationStarted(new FileOperationEventArgs { File = Address });
-                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe get --json " + Address,
+                GetCommandLineOutputEvent(GinCliExe, " get --json " + Address,
                     PhysicalDirectory.Parent.FullName, out var error);
                 var result = string.IsNullOrEmpty(error);
                 if (result)
@@ -463,7 +464,7 @@ namespace GinClientLibrary
             if (performFullCheckout)
             {
                 OnFileOperationStarted(new FileOperationEventArgs { File = Address });
-                GetCommandLineOutputEvent("cmd.exe", "/C gin.exe download --json --content",
+                GetCommandLineOutputEvent(GinCliExe, " download --json --content",
                     PhysicalDirectory.FullName, out var error);
                 var result = string.IsNullOrEmpty(error);
                 if (result)

--- a/GinClientLibrary/RepositoryManager.cs
+++ b/GinClientLibrary/RepositoryManager.cs
@@ -75,7 +75,7 @@ namespace GinClientLibrary
                     {
                         WindowStyle = ProcessWindowStyle.Hidden,
                         FileName = @GinCliExe,
-                        WorkingDirectory = GinCliPath,
+                        WorkingDirectory = @GinCliPath,
                         Arguments = "use-server \""+alias+"\"",
                         CreateNoWindow = true,
                         RedirectStandardOutput = true,
@@ -109,7 +109,7 @@ namespace GinClientLibrary
                     {
                         WindowStyle = ProcessWindowStyle.Hidden,
                         FileName = @GinCliExe,
-                        WorkingDirectory = GinCliPath,
+                        WorkingDirectory = @GinCliPath,
                         Arguments = " logout",
                         CreateNoWindow = true,
                         RedirectStandardOutput = true,
@@ -120,6 +120,7 @@ namespace GinClientLibrary
                 };
 
                 process.Start();
+                process.WaitForExit();
             }
         }
 
@@ -133,7 +134,7 @@ namespace GinClientLibrary
                     {
                         WindowStyle = ProcessWindowStyle.Hidden,
                         FileName = @GinCliExe,
-                        WorkingDirectory = GinCliPath,
+                        WorkingDirectory = @GinCliPath,
                         Arguments = " create --no-clone \"" + repoName+"\"",
                         CreateNoWindow = true,
                         RedirectStandardOutput = true,
@@ -164,7 +165,7 @@ namespace GinClientLibrary
                     {
                         WindowStyle = ProcessWindowStyle.Hidden,
                         FileName = @GinCliExe,
-                        WorkingDirectory = GinCliPath,
+                        WorkingDirectory = @GinCliPath,
                         Arguments = "servers --json ",
                         CreateNoWindow = true,
                         RedirectStandardOutput = true,
@@ -204,7 +205,7 @@ namespace GinClientLibrary
                     {
                         WindowStyle = ProcessWindowStyle.Hidden,
                         FileName = @GinCliExe,
-                        WorkingDirectory = GinCliPath,
+                        WorkingDirectory = @GinCliPath,
                         Arguments = "add-server --web "+ web + " --git "+git+" "+ "\""+alias+"\"" ,
                         CreateNoWindow = true,
                         RedirectStandardOutput = true,
@@ -243,7 +244,7 @@ namespace GinClientLibrary
                     {
                         WindowStyle = ProcessWindowStyle.Hidden,
                         FileName = @GinCliExe,
-                        WorkingDirectory = GinCliPath,
+                        WorkingDirectory = @GinCliPath,
                         Arguments = "remove-server "  + "\""+alias+"\"",
                         CreateNoWindow = true,
                         RedirectStandardOutput = true,
@@ -276,7 +277,7 @@ namespace GinClientLibrary
                     {
                         WindowStyle = ProcessWindowStyle.Hidden,
                         FileName = @GinCliExe,
-                        WorkingDirectory = GinCliPath,
+                        WorkingDirectory = @GinCliPath,
                         Arguments = " login \"" + username +"\" --server "+ "\""+serverAlias+"\"",
                         CreateNoWindow = true,
                         RedirectStandardOutput = true,
@@ -338,7 +339,7 @@ namespace GinClientLibrary
                 {
                     WindowStyle = ProcessWindowStyle.Hidden,
                     FileName = @GinCliExe,
-                    WorkingDirectory = GinCliPath,
+                    WorkingDirectory = @GinCliPath,
                     Arguments = " --version",
                     CreateNoWindow = true,
                     RedirectStandardOutput = true,
@@ -558,7 +559,7 @@ namespace GinClientLibrary
                 {
                     WindowStyle = ProcessWindowStyle.Hidden,
                     FileName = @GinCliExe,
-                    WorkingDirectory = GinCliPath,
+                    WorkingDirectory = @GinCliPath,
                     Arguments = "repos --json --all",
                     CreateNoWindow = true,
                     RedirectStandardOutput = true,
@@ -585,8 +586,8 @@ namespace GinClientLibrary
                 StartInfo = new ProcessStartInfo
                 {
                     WindowStyle = ProcessWindowStyle.Hidden,
-                    FileName = GinCliExe,
-                    WorkingDirectory = GinCliPath,
+                    FileName = @GinCliExe,
+                    WorkingDirectory = @GinCliPath,
                     Arguments = "repoinfo --json " + path,
                     CreateNoWindow = true,
                     RedirectStandardOutput = true,

--- a/GinClientLibrary/RepositoryManager.cs
+++ b/GinClientLibrary/RepositoryManager.cs
@@ -36,7 +36,7 @@ namespace GinClientLibrary
 
         private readonly object _thisLock = new object();
 
-        private readonly string GinCliPath = AppDomain.CurrentDomain.BaseDirectory+"gin-cli\\";
+        private readonly string GinCliPath = AppDomain.CurrentDomain.BaseDirectory+"gin-cli\\bin\\";
 
         private List<GinRepository> _repositories;
 

--- a/GinClientLibrary/RepositoryManager.cs
+++ b/GinClientLibrary/RepositoryManager.cs
@@ -144,6 +144,7 @@ namespace GinClientLibrary
                 };
 
                 process.Start();
+                process.WaitForExit();
             }
 
             return true;

--- a/GinClientLibrary/RepositoryManager.cs
+++ b/GinClientLibrary/RepositoryManager.cs
@@ -37,6 +37,7 @@ namespace GinClientLibrary
         private readonly object _thisLock = new object();
 
         private readonly string GinCliPath = AppDomain.CurrentDomain.BaseDirectory+"gin-cli\\bin\\";
+        private readonly string GinCliExe = "\""+AppDomain.CurrentDomain.BaseDirectory + "gin-cli\\bin\\gin.exe\"";
 
         private List<GinRepository> _repositories;
 
@@ -73,7 +74,7 @@ namespace GinClientLibrary
                     StartInfo = new ProcessStartInfo
                     {
                         WindowStyle = ProcessWindowStyle.Hidden,
-                        FileName = "gin.exe",
+                        FileName = @GinCliExe,
                         WorkingDirectory = GinCliPath,
                         Arguments = "use-server \""+alias+"\"",
                         CreateNoWindow = true,
@@ -107,9 +108,9 @@ namespace GinClientLibrary
                     StartInfo = new ProcessStartInfo
                     {
                         WindowStyle = ProcessWindowStyle.Hidden,
-                        FileName = "cmd.exe",
+                        FileName = @GinCliExe,
                         WorkingDirectory = GinCliPath,
-                        Arguments = "/C gin.exe logout",
+                        Arguments = " logout",
                         CreateNoWindow = true,
                         RedirectStandardOutput = true,
                         RedirectStandardError = true,
@@ -131,9 +132,9 @@ namespace GinClientLibrary
                     StartInfo = new ProcessStartInfo
                     {
                         WindowStyle = ProcessWindowStyle.Hidden,
-                        FileName = "cmd.exe",
+                        FileName = @GinCliExe,
                         WorkingDirectory = GinCliPath,
-                        Arguments = "/C gin.exe create --no-clone " + repoName,
+                        Arguments = " create --no-clone \"" + repoName+"\"",
                         CreateNoWindow = true,
                         RedirectStandardOutput = true,
                         RedirectStandardError = true,
@@ -161,7 +162,7 @@ namespace GinClientLibrary
                     StartInfo = new ProcessStartInfo
                     {
                         WindowStyle = ProcessWindowStyle.Hidden,
-                        FileName = "gin.exe",
+                        FileName = @GinCliExe,
                         WorkingDirectory = GinCliPath,
                         Arguments = "servers --json ",
                         CreateNoWindow = true,
@@ -201,7 +202,7 @@ namespace GinClientLibrary
                     StartInfo = new ProcessStartInfo
                     {
                         WindowStyle = ProcessWindowStyle.Hidden,
-                        FileName = "gin.exe",
+                        FileName = @GinCliExe,
                         WorkingDirectory = GinCliPath,
                         Arguments = "add-server --web "+ web + " --git "+git+" "+ "\""+alias+"\"" ,
                         CreateNoWindow = true,
@@ -240,7 +241,7 @@ namespace GinClientLibrary
                     StartInfo = new ProcessStartInfo
                     {
                         WindowStyle = ProcessWindowStyle.Hidden,
-                        FileName = "gin.exe",
+                        FileName = @GinCliExe,
                         WorkingDirectory = GinCliPath,
                         Arguments = "remove-server "  + "\""+alias+"\"",
                         CreateNoWindow = true,
@@ -273,9 +274,9 @@ namespace GinClientLibrary
                     StartInfo = new ProcessStartInfo
                     {
                         WindowStyle = ProcessWindowStyle.Hidden,
-                        FileName = "cmd.exe",
+                        FileName = @GinCliExe,
                         WorkingDirectory = GinCliPath,
-                        Arguments = @"/C gin.exe login " + username +" --server "+ "\""+serverAlias+"\"",
+                        Arguments = " login \"" + username +"\" --server "+ "\""+serverAlias+"\"",
                         CreateNoWindow = true,
                         RedirectStandardOutput = true,
                         RedirectStandardError = true,
@@ -335,9 +336,9 @@ namespace GinClientLibrary
                 StartInfo = new ProcessStartInfo
                 {
                     WindowStyle = ProcessWindowStyle.Hidden,
-                    FileName = "cmd.exe",
+                    FileName = @GinCliExe,
                     WorkingDirectory = GinCliPath,
-                    Arguments = @"/C gin.exe --version",
+                    Arguments = " --version",
                     CreateNoWindow = true,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
@@ -555,7 +556,7 @@ namespace GinClientLibrary
                 StartInfo = new ProcessStartInfo
                 {
                     WindowStyle = ProcessWindowStyle.Hidden,
-                    FileName = "gin.exe",
+                    FileName = @GinCliExe,
                     WorkingDirectory = GinCliPath,
                     Arguments = "repos --json --all",
                     CreateNoWindow = true,
@@ -583,7 +584,7 @@ namespace GinClientLibrary
                 StartInfo = new ProcessStartInfo
                 {
                     WindowStyle = ProcessWindowStyle.Hidden,
-                    FileName = "gin.exe",
+                    FileName = GinCliExe,
                     WorkingDirectory = GinCliPath,
                     Arguments = "repoinfo --json " + path,
                     CreateNoWindow = true,


### PR DESCRIPTION
Fixed wrong path to gin-cli
Removed all cmd calls, now called gin.exe directly
Fixed several typos
Changed folder names for wingin settings - old settings are not moved 
Fixed remove repository behavior when the current settings was not saved until OK button in WinGIN was clicked